### PR TITLE
Custom HTTP client support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ linters:
     - gosec
     - lll
     - maligned
+    - bodyclose

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: go
 install:
   - go get github.com/mattn/goveralls
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.12
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
 go:
   - "1.11"
 before_script:

--- a/gcore/gcore.go
+++ b/gcore/gcore.go
@@ -173,12 +173,70 @@ func NewCommonClient(logger ...log.GenericLogger) *CommonClient {
 	return commonClient
 }
 
+// NewCommonClientWithCustomHTTP creates basic G-Core client with custom HTTP client.
+func NewCommonClientWithCustomHTTP(customClient *http.Client, logger ...log.GenericLogger) *CommonClient {
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	if customClient == nil {
+		customClient = NewHTTPClient()
+	}
+
+	c := &Client{
+		client:    customClient,
+		BaseURL:   baseURL,
+		UserAgent: defaultUserAgent,
+		log:       log.SelectLogger(logger...),
+	}
+	c.common.client = c
+
+	commonServices := CommonServices{}
+	commonServices.Account = (*AccountService)(&c.common)
+	commonServices.Resources = (*ResourcesService)(&c.common)
+	commonServices.OriginGroups = (*OriginGroupsService)(&c.common)
+	commonServices.Rules = (*RulesService)(&c.common)
+	commonServices.Certificates = (*CertService)(&c.common)
+
+	commonClient := &CommonClient{
+		Client:         c,
+		CommonServices: commonServices,
+	}
+
+	return commonClient
+}
+
 // NewResellerClient creates reseller G-Core client.
 func NewResellerClient(logger ...log.GenericLogger) *ResellerClient {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	c := &Client{
 		client:    NewHTTPClient(),
+		BaseURL:   baseURL,
+		UserAgent: defaultUserAgent,
+		log:       log.SelectLogger(logger...),
+	}
+	c.common.client = c
+
+	resellerServices := ResellerServices{}
+	resellerServices.Clients = (*ClientsService)(&c.common)
+	resellerServices.GeoRestrictions = (*GeoRestrictionsService)(&c.common)
+	resellClient := &ResellerClient{
+		Client:           c,
+		ResellerServices: resellerServices,
+	}
+
+	return resellClient
+}
+
+// NewResellerClientWithCustomHTTP creates reseller G-Core client with custom HTTP client.
+func NewResellerClientWithCustomHTTP(customClient *http.Client, logger ...log.GenericLogger) *ResellerClient {
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	if customClient == nil {
+		customClient = NewHTTPClient()
+	}
+
+	c := &Client{
+		client:    customClient,
 		BaseURL:   baseURL,
 		UserAgent: defaultUserAgent,
 		log:       log.SelectLogger(logger...),

--- a/gcore/gcore_test.go
+++ b/gcore/gcore_test.go
@@ -2,7 +2,9 @@ package gcore
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	th "github.com/dstdfx/go-gcore/gcore/internal/testhelper"
 )
@@ -29,11 +31,87 @@ func TestNewCommonClient(t *testing.T) {
 	}
 }
 
+func TestNewCommonClientWithCustomHTTP(t *testing.T) {
+	testEnv := th.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	common := NewCommonClientWithCustomHTTP(customClient)
+	common.BaseURL = testEnv.GetServerURL()
+
+	err := common.Authenticate(context.Background(), TestFakeAuthOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if common.Token.Value != th.TestFakeToken {
+		t.Errorf("Expected: %s, got %s", th.TestFakeToken, common.Token.Value)
+	}
+}
+
+func TestNewCommonClientWithNilCustomHTTP(t *testing.T) {
+	testEnv := th.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	common := NewCommonClientWithCustomHTTP(nil)
+	common.BaseURL = testEnv.GetServerURL()
+
+	err := common.Authenticate(context.Background(), TestFakeAuthOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if common.Token.Value != th.TestFakeToken {
+		t.Errorf("Expected: %s, got %s", th.TestFakeToken, common.Token.Value)
+	}
+}
+
 func TestNewResellerClient(t *testing.T) {
 	testEnv := th.SetupTestEnv()
 	defer testEnv.TearDownTestEnv()
 
 	reseller := NewResellerClient()
+	reseller.BaseURL = testEnv.GetServerURL()
+
+	err := reseller.Authenticate(context.Background(), TestFakeAuthOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reseller.Token.Value != th.TestFakeToken {
+		t.Errorf("Expected: %s, got %s", th.TestFakeToken, reseller.Token.Value)
+	}
+}
+
+func TestNewResellerClientWithCustomHTTP(t *testing.T) {
+	testEnv := th.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	reseller := NewResellerClientWithCustomHTTP(customClient)
+	reseller.BaseURL = testEnv.GetServerURL()
+
+	err := reseller.Authenticate(context.Background(), TestFakeAuthOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reseller.Token.Value != th.TestFakeToken {
+		t.Errorf("Expected: %s, got %s", th.TestFakeToken, reseller.Token.Value)
+	}
+}
+
+func TestNewResellerClientWithNilCustomHTTP(t *testing.T) {
+	testEnv := th.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	reseller := NewResellerClientWithCustomHTTP(nil)
 	reseller.BaseURL = testEnv.GetServerURL()
 
 	err := reseller.Authenticate(context.Background(), TestFakeAuthOptions)


### PR DESCRIPTION
For #20 

* Add ability to specify custom HTTP client during common/reseller
clients initializations